### PR TITLE
Only require coveralls gem in development

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     mail_safe (0.3.2)
       actionmailer (>= 3.0.0)
-      coveralls
 
 GEM
   remote: https://rubygems.org/
@@ -92,6 +91,7 @@ PLATFORMS
 DEPENDENCIES
   appraisal
   bundler
+  coveralls
   mail_safe!
   rake
   rspec (~> 3.0, >= 3.0.0)

--- a/mail_safe.gemspec
+++ b/mail_safe.gemspec
@@ -25,12 +25,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "actionmailer", ">= 3.0.0"
-  spec.add_dependency "coveralls"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0", ">= 3.0.0"
   spec.add_development_dependency "appraisal"
+  spec.add_development_dependency "coveralls"
 
   spec.required_ruby_version = ">= 1.9.3"
 end


### PR DESCRIPTION
I'd rather not include `coveralls` as a dependency for my app. Would you be amenable to just making it a development dependency?
